### PR TITLE
Fix duplication when forwarding telegram messages

### DIFF
--- a/pmi_proxy_bot/telegram_message_handler.py
+++ b/pmi_proxy_bot/telegram_message_handler.py
@@ -120,20 +120,21 @@ class TelegramMessageHandler:
                 reply_to_message_str = f"\n>> <i>от <a href=\"{reply_profile_url}\"><b>{reply_sender_name}</b></a>: {reply_text}</i>"
         combined_text = f"<a href=\"{profile_url}\">{emoji} {sender_name}</a>:\n"
         main_attachments = []
-        if text:
-            combined_text += text
         messages = [message]
         if message.get('media_group_id'):
             messages = self.media_groups_buffer.pop(message['media_group_id'], [message])
         media_items = []
         doc_attachments = []
-        for msg in messages:
+        for i, msg in enumerate(messages):
             if msg.get('media_group_id'):
                 text = msg.get('caption', '')
             else:
-                text = msg.get('text', '')
+                text = msg.get('text', '') or msg.get('caption', '')
             if text:
-                combined_text += "\n" + text
+                if i == 0:
+                    combined_text += text
+                else:
+                    combined_text += "\n" + text
             if 'photo' in msg:
                 photo_sizes = msg['photo']
                 best_photo = max(photo_sizes, key=lambda p: p.get('width', 0))

--- a/tests/test_forward_duplicates.py
+++ b/tests/test_forward_duplicates.py
@@ -1,0 +1,28 @@
+import re
+from pmi_proxy_bot.telegram_message_handler import TelegramMessageHandler
+from pmi_proxy_bot.database_manager import DatabaseManager
+
+class DummyService:
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            return None
+        return method
+
+class CaptureVK:
+    def __init__(self):
+        self.chat_id = 1
+        self.sent_messages = []
+    def upload_photo(self, *a, **k):
+        return None
+    def upload_document(self, *a, **k):
+        return None
+    def send_message(self, peer_id, message, attachment=None, format_data=None, chat_id=None):
+        self.sent_messages.append(message)
+
+def test_forward_text_no_duplicate():
+    vk = CaptureVK()
+    handler = TelegramMessageHandler(DummyService(), vk, DatabaseManager(':memory:'))
+    msg = {'chat': {'id': 1}, 'text': 'hello', 'from': {'first_name': 'John', 'last_name': 'Doe'}}
+    handler.forward_to_vk(msg)
+    assert len(vk.sent_messages) == 1
+    assert len(re.findall('hello', vk.sent_messages[0])) == 1


### PR DESCRIPTION
## Summary
- ensure Telegram message text isn't appended twice when forwarding to VK
- add regression test for forwarding duplicate issue

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588b21e8d8832ebbb18154c0859b54